### PR TITLE
Add output.guessed_function_arn

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -2,6 +2,20 @@
 # OUTPUT CALCULATED VARIABLES (prefer full objects)
 # ----------------------------------------------------------------------------------------------------------------------
 
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+locals {
+  region       = data.aws_region.current.name
+  account_id   = data.aws_caller_identity.current.account_id
+  function_arn = "arn:aws:lambda:${local.region}:${local.account_id}:function:${var.function_name}"
+}
+
+output "guessed_function_arn" {
+  description = "Guessed function arn in the format: arn:aws:lambda:<region>:<account_id>:function:<function_name>"
+  value       = local.function_arn
+}
+
 # ----------------------------------------------------------------------------------------------------------------------
 # OUTPUT ALL RESOURCES AS FULL OBJECTS
 # ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
create the arn of the function only from input variables so we can reuse it in other
modules without depending on the actual function resource.

This prevents recreation of lambda permissions in cases where connected to cognito.
